### PR TITLE
Random bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To create a 32 bit (standard) CDB file:
 
 ```ruby
     PureCDB::Writer.open("/tmp/somecdbfile.cdb") do |cdb| 
-     cdb.add("key","value")
+     cdb.store("key","value")
     end
 ```
 

--- a/lib/purecdb/reader.rb
+++ b/lib/purecdb/reader.rb
@@ -83,7 +83,7 @@ module PureCDB
     #
     def close
       @io.close if @io
-      @m.unmap if @m
+      @m.munmap if @m
       @m = nil
       @io = nil
     end


### PR DESCRIPTION
I found a few small bugs and typos. Apparently the method for unmapping for FFI::Mmaps is munmap rather than just unmap (also broken in FFI::Mmap 0.2.0 but that bug seems to be already fixed in git head). README.md refers to a nonexistent PureCDB::Writer#add method, the correct one seems to be PureCDB::Writer#store.