### PR TITLE
PureCDB::Reader.open and PureCDB::Writer can accept Pathname object

### DIFF
--- a/lib/purecdb/reader.rb
+++ b/lib/purecdb/reader.rb
@@ -27,14 +27,18 @@ module PureCDB
     # filename
     # 
     def initialize target, *options
-      if target.is_a?(String)
+      pathname = self.class.const_defined?(:Pathname) ? Pathname : String
+      case target
+      when String, pathname
         @name = target
         @io = File.new(target,"rb")
         raise "Unable to open file #{target}" if !@io
-      else
+      when IO, StringIO
         set_stream(target)
+      else
+        raise ArgumentError, "#{target} should be String, Pathname, IO"
       end
-      
+
       @io.sysseek(-8,IO::SEEK_END)
       tail = @io.sysread(8)
       raise "Unable to read trailing 8 bytes for magic cookie" if tail.size != 8

--- a/lib/purecdb/writer.rb
+++ b/lib/purecdb/writer.rb
@@ -55,10 +55,16 @@ module PureCDB
 
       set_mode(32) if @mode == :detect
 
-      if target.is_a?(String)
-        @io = File.new(target,"wb")
-      else
+      pathname = self.class.const_defined?(:Pathname) ? Pathname : String
+      case target
+      when String, pathname
+        @name = target
+        @io = File.new(target,"rb")
+        raise "Unable to open file #{target}" if !@io
+      when IO, StringIO
         set_stream(target)
+      else
+        raise ArgumentError, "#{target} should be String, Pathname"
       end
 
       @hashes = [nil] * num_hashes

--- a/spec/purecdb_spec.rb
+++ b/spec/purecdb_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pathname'
 
 describe PureCDB do
   let(:strio) { StringIO.new }
@@ -81,6 +82,19 @@ describe PureCDB do
     specify "will use FFI::Mmap when passed a filename if possible" do
       f = create_cdb_other(pairs)
       r = PureCDB::Reader.open(f)
+      expect(r.mmap?).to be true
+      pairs.each do |k,v|
+        expect(r.values(k)).to eq([v])
+      end
+      # Mmap will be switched off during read if it fails, so check again
+      # after reading back the key/values
+      expect(r.mmap?).to be true
+    end
+
+    specify "PureCDB::Reader.open(pathname)" do
+      create_cdb_other(pairs)
+      pathname = Pathname.new("/tmp/test.cdb")
+      r = PureCDB::Reader.open(pathname)
       expect(r.mmap?).to be true
       pairs.each do |k,v|
         expect(r.values(k)).to eq([v])


### PR DESCRIPTION

```
PureCDB::Reader.open(Rails.root + "db/foo.cdb")
```
will fail because `Rails.root + "db/foo.cdb"` is not String but Pathname object.

We would not like to write 
```
PureCDB::Reader.open((Rails.root + "db/foo.cdb").to_s)
```
because it is redundant

